### PR TITLE
Fix AttributeError: module 'crocoddyl' has no attribute 'Thruster'

### DIFF
--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -9,6 +9,7 @@ import pinocchio
 
 from .libcrocoddyl_pywrap import *  # noqa: F403
 from .libcrocoddyl_pywrap import __raw_version__, __version__  # noqa: F401
+from .multibody.actuations.floating_base_thrusters import Thruster
 
 
 def rotationMatrixFromTwoVectors(a, b):


### PR DESCRIPTION
Related to #3

Add the `Thruster` class to the `crocoddyl` module.

* Import `Thruster` from `multibody.actuations.floating_base_thrusters` in `bindings/python/crocoddyl/__init__.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jhurliman/crocoddyl/issues/3?shareId=2067d4b9-c294-41a2-85e5-89be8f8b2443).